### PR TITLE
fix(windows): properly create shells for windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ const executeScript = (binary, args) => {
       ...process.env,
       PATH: [process.env.PATH, ...getNodeBinaryFolders(process.cwd())].join(delimiter),
     },
+    shell: true,
   });
 
   script.on('error', err => {


### PR DESCRIPTION
Correctly spawns child processes for windows.

https://nodejs.org/api/child_process.html

"The importance of the distinction between child_process.exec() and child_process.execFile() can vary based on platform. On Unix-type operating systems (Unix, Linux, macOS) child_process.execFile() can be more efficient because it does not spawn a shell by default. On Windows, however, .bat and .cmd files are not executable on their own without a terminal, and therefore cannot be launched using child_process.execFile(). When running on Windows, .bat and .cmd files can be invoked using child_process.spawn() with the shell option set, with child_process.exec(), or by spawning cmd.exe and passing the .bat or .cmd file as an argument (which is what the shell option and child_process.exec() do)." 